### PR TITLE
Various fixes to routes that are showing bugs (#75)

### DIFF
--- a/api/models/BaseObject.js
+++ b/api/models/BaseObject.js
@@ -85,7 +85,7 @@ module.exports = class BaseObject {
 
   set disallowedProperties(arr) {
     if (this._disallowedProperties) {
-      this._disallowedProperties.push(arr);
+      this._disallowedProperties = this._disallowedProperties.concat(arr);
     } else {
       this._disallowedProperties = arr;
     }
@@ -209,6 +209,12 @@ module.exports = class BaseObject {
       .where(`${this.columnName} = ?`, this.id)
       .toParam();
     query.text = query.text.concat(';');
-    return this.uow.query(query.text, query.values);
+    return this.uow.query(query.text, query.values)
+      .catch((err) => {
+        if (err.errno === 1217) { // Foreign key validation failed
+          throw new HttpError({ message: 'Cannot delete as this object is referenced elsewhere', err }, 400);
+        }
+        throw err;
+      });
   }
 };

--- a/api/models/CheckoutItem.js
+++ b/api/models/CheckoutItem.js
@@ -27,14 +27,22 @@ module.exports.CheckoutItem = class CheckoutItem extends BaseObject {
   }
 
   static getAllAvailable(uow) {
+    const subquery = squel.select({
+      autoQuoteTableNames: false,
+      autoQuoteFieldNames: false,
+    })
+      .from(CheckoutData.TABLE_NAME, 'c')
+      .field('COUNT(uid)')
+      .where('c.item_id=i.uid')
+      .toString();
     const query = squel.select({
       autoQuoteTableNames: true,
       autoQuoteFieldNames: false,
     })
-      .fields(['i.quantity - SUM(ISNULL(c.return_time)) AS available', 'i.*'])
-      .from(CheckoutData.TABLE_NAME, 'c')
-      .join(TABLE_NAME, 'i', 'c.item_id=i.uid')
-      .join(Hackathon.TABLE_NAME, 'h', 'c.hackathon=h.uid and h.active=1')
+      .fields([`i.quantity - (${subquery}) AS available`, 'i.*'])
+      .from(TABLE_NAME, 'i')
+      .left_join(CheckoutData.TABLE_NAME, 'c', 'c.item_id=i.uid')
+      .left_join(Hackathon.TABLE_NAME, 'h', 'c.hackathon=h.uid and h.active=1')
       .group('i.uid')
       .toParam();
     return uow.query(query.text, query.values, { stream: true });

--- a/api/models/CheckoutObject.js
+++ b/api/models/CheckoutObject.js
@@ -63,7 +63,7 @@ module.exports.CheckoutObject = class CheckoutObject extends BaseObject {
       .join('CHECKOUT_ITEMS', 'i', 'item_id=i.uid')
       .join(Registration.TABLE_NAME, 'u', 'user_id=u.uid');
     if (opts && opts.currentHackathon) {
-      query = query.join(Hackathon.TABLE_NAME, 'h', 'checkout_data.hackathon=h.uid and h.active=1');
+      query = query.join(Hackathon.TABLE_NAME, 'h', 'checkout_data.hackathon=h.uid and h.active=1 and u.hackathon=h.uid');
     }
     query = query.toParam();
     return uow.query(query.text, query.values, { stream: true });

--- a/api/models/Registration.js
+++ b/api/models/Registration.js
@@ -144,6 +144,30 @@ module.exports.Registration = class Registration extends BaseObject {
 
   /**
    *
+   * This method should be migrated to RFID Assignments model
+   */
+  static getAllRfidAssignments(uow, opts) {
+    if (opts && opts.currentHackathon) {
+      const query = squel.select({
+        autoQuoteTableNames: opts.quoteFields !== false,
+        autoQuoteFieldNames: opts.quoteFields !== false,
+      })
+        .from(TABLE_NAME, 'reg')
+        .fields(opts.fields || null)
+        .offset(opts.startAt || null)
+        .limit(opts.count || null)
+        .join(HackathonTableName, 'hackathon', 'hackathon.active = 1 and reg.hackathon = hackathon.uid')
+        .left_join('RFID_ASSIGNMENTS', 'rfid', 'rfid.user_uid = reg.uid and rfid.hackathon = reg.hackathon')
+        .toString()
+        .concat(';');
+      const params = [];
+      return uow.query(query, params, { stream: true });
+    }
+    return super.getAll(uow, TABLE_NAME, opts);
+  }
+
+  /**
+   *
    * @param uow
    * @param opts
    * @return {Promise<Stream>}
@@ -248,6 +272,7 @@ module.exports.Registration = class Registration extends BaseObject {
       .field(`"${value}"`, 'CATEGORY')
       .field(value, 'OPTION')
       .field('COUNT(*)', 'COUNT')
+      .join(HackathonTableName, 'hackathon', `hackathon.uid = ${TABLE_NAME}.hackathon and hackathon.active = 1`)
       .group(value);
   }
 

--- a/api/models/Update.js
+++ b/api/models/Update.js
@@ -69,6 +69,8 @@ module.exports.Update = class Update extends BaseObject {
       return Promise.reject(new Error(validation.error));
     }
     const uid = new Timeuuid().toString();
+    console.log(this._dbRepresentation);
+    console.log(this.disallowedProperties);
     return this.hackathonPromise.then(() => this.uow.query(RtdbUow.queries.SET, `${REFERENCE}/${uid}`, this._dbRepresentation));
   }
 

--- a/api/routes/admin/admin.js
+++ b/api/routes/admin/admin.js
@@ -4,7 +4,7 @@ const Ajv = require('ajv');
 const express = require('express');
 const _ = require('lodash');
 const { emailObjectSchema, rfidAssignmentSchema } =
-  require('../../assets/schemas/load-schemas')(['emailObjectSchema', 'rfidAssignmentSchema']);
+        require('../../assets/schemas/load-schemas')(['emailObjectSchema', 'rfidAssignmentSchema']);
 const database = require('../../services/database');
 const {
   verifyACL, elevate, getUserId, verifyAuthMiddleware,
@@ -529,8 +529,8 @@ router.post(['/create_location', '/location'], verifyACL(3), (req, res, next) =>
 router.post(['/update_location', '/location/update'], verifyACL(3), (req, res, next) => {
   if (!req.body ||
       !req.body.uid ||
-      !req.body.location_name ||
-      req.body.location_name.length === 0 ||
+      !req.body.locationName ||
+      req.body.locationName.length === 0 ||
       req.body.uid.length === 0) {
     const error = new Error();
     error.status = 400;
@@ -726,12 +726,13 @@ router.post('/email', verifyACL(3), validateEmails, (req, res, next) => {
           req.body.subject,
           req.body.fromEmail,
         )))
-      .then(request =>
-        ({
-          email: request.to,
+      .then(() => (
+        {
+          email: emailObject.email,
           response: 'success',
           name: emailObject.name,
-        }))
+        }
+      ))
       .catch((error) => {
         // Else add to the failArray for the partial HTTP success response
         res.locals.failArray.push(_.assign(emailObject, error));
@@ -739,7 +740,7 @@ router.post('/email', verifyACL(3), validateEmails, (req, res, next) => {
       }));
   Promise.all(promises)
     .then((resolution) => {
-      const resolves = resolution.filter(result => result !== null);
+      const resolves = resolution.filter(result => result);
       if (resolves.length === 0) {
         const error = new Error();
         error.status = 500;
@@ -764,7 +765,7 @@ router.post('/email', verifyACL(3), validateEmails, (req, res, next) => {
         recipient_name: errorEmail.name || null,
         time: new Date().getTime(),
       })) : null)
-        .catch(logger.error);
+        .catch(error => logger.error(error));
       if (res.locals.failArray.length === 0) {
         return res.status(200)
           .send(resolves); // Full success response
@@ -773,7 +774,7 @@ router.post('/email', verifyACL(3), validateEmails, (req, res, next) => {
       res.status(207)
         .send(res.locals.failArray.concat(resolves));
     })
-    .catch(logger.error);
+    .catch(error => logger.error(error));
 });
 
 /**

--- a/api/routes/live.js
+++ b/api/routes/live.js
@@ -1,7 +1,9 @@
 /* eslint-disable consistent-return */
 const express = require('express');
 const { verifyAuthMiddleware, verifyACL } = require('../services/auth');
-const { errorHandler500, streamHandler, sendNotification } = require('../services/functions');
+const {
+  errorHandler500, streamHandler, sendNotification, standardErrorHandler,
+} = require('../services/functions');
 const { Update } = require('../models/Update');
 const { Event } = require('../models/Event');
 const HttpError = require('../JSCommon/HttpError');
@@ -202,7 +204,7 @@ router.post('/event/delete', verifyACL(2), (req, res, next) => {
   const event = new Event({ uid: req.body.uid }, req.uow);
   event.delete()
     .then(() => res.status(200).send({ message: 'Success' }))
-    .catch(err => errorHandler500(err, next));
+    .catch(err => standardErrorHandler(err, next));
 });
 
 module.exports = router;

--- a/api/routes/scanner.js
+++ b/api/routes/scanner.js
@@ -60,7 +60,7 @@ router.use((req, res, next) => {
  * @apiUse IllegalArgumentError
  */
 router.get('/registrations', (req, res, next) => {
-  Registration.getAll(
+  Registration.getAllRfidAssignments(
     req.uow,
     {
       fields: ['reg.uid',
@@ -73,7 +73,9 @@ router.get('/registrations', (req, res, next) => {
         'reg.firstname',
         'reg.lastname',
         'reg.shirt_size',
-        'reg.dietary_restriction'],
+        'reg.dietary_restriction',
+        'rfid.rfid_uid',
+      ],
       currentHackathon: true,
       quoteFields: false,
     },

--- a/api/services/database.js
+++ b/api/services/database.js
@@ -149,6 +149,7 @@ function addRfidScans(uow, scans) {
  */
 function getAllUsersList(uow) {
   let query = squel.select({ autoQuoteFieldNames: false, autoQuoteTableNames: true })
+    .distinct()
     .field('pre_reg.uid', 'pre_uid')
     .field('reg.*')
     .field('reg.pin - hackathon.base_pin', 'pin')
@@ -180,8 +181,7 @@ function getAllUsersCount(uow) {
   let query = squel.select({ autoQuoteTableNames: true, autoQuoteFieldNames: true })
     .from(squel.select({ autoQuoteTableNames: true, autoQuoteFieldNames: false })
       .from(PreRegistration.TABLE_NAME, 'prereg')
-      .field('COUNT(prereg.uid)', 'pre_count')
-      .join(Hackathon.TABLE_NAME, 'hackathon', 'hackathon.uid = prereg.hackathon AND hackathon.active = 1'), 'a')
+      .field('COUNT(prereg.uid)', 'pre_count'), 'a')
     .join(squel.select({ autoQuoteTableNames: true, autoQuoteFieldNames: false })
       .from(Registration.TABLE_NAME, 'registration')
       .field('COUNT(registration.uid)', 'reg_count')


### PR DESCRIPTION
* Fixed statistics route to only send current hackathon data

* Fixed up some issues with email send

* Added distinct selection for user_data

Signed-off-by: Sushrut Shringarputale <contact@sushshring.com>

* Fixed issue for update location route.

Signed-off-by: Sushrut Shringarputale <contact@sushshring.com>

* Better error handling on object deletion for foreign key failure.

Signed-off-by: Sushrut Shringarputale <contact@sushshring.com>

* Fixed error for live update sending

* Fixed an error where a person with multiple registrations across hackathons would appear twice on the checkout data list

Signed-off-by: Sushrut Shringarputale <contact@sushshring.com>

* Fixed query in checkout availablility that did the wrong aggregation or failed if there was no data in the joined tables.

Signed-off-by: Sushrut Shringarputale <contact@sushshring.com>

* Fixed query in checkout availability that did the wrong aggregation or failed if there was no data in the joined tables.

Signed-off-by: Sushrut Shringarputale <contact@sushshring.com>

* Added a join on rfids to scanner retrieval

* Fixed error handler for event delete

Signed-off-by: Sushrut Shringarputale <contact@sushshring.com>