### PR TITLE
Cleaner api <-> model <-> db data flow

### DIFF
--- a/src/models/BaseObject.ts
+++ b/src/models/BaseObject.ts
@@ -1,13 +1,15 @@
 /* eslint-disable no-underscore-dangle,no-param-reassign,class-methods-use-this */
 import ajv from 'ajv';
+import * as crypto from 'crypto';
 import { default as _ } from 'lodash';
+import { IApiModel } from '../services/database';
 
 const ajvValidator = new ajv();
 /**
  * @class BaseObject
  * The base object definition for any table in the database
  */
-export default abstract class  BaseObject {
+export default abstract class BaseObject {
 
   /**
    * Returns a representation of the object that can be added directly to the database
@@ -29,7 +31,7 @@ export default abstract class  BaseObject {
    * are any other fields in subclasses that should not be present in an instance
    * of the object sent for APIs, override this method and delete those there
    */
-  public get cleanRepresentation() {
+  public get cleanRepresentation(): IApiModel<this> {
     const clone = { ...this };
     // @ts-ignore
     delete clone.disallowedPropertiesInternal;
@@ -72,13 +74,16 @@ export default abstract class  BaseObject {
    */
   protected abstract get schema(): any;
 
+  public magicNumber: number;
+
   /*********** PROPERTIES *************/
   // In a sub-class, make sure this array also includes all super properties
   protected readonly disallowedPropertiesInternal: Set<string>;
 
   protected constructor() {
+    this.magicNumber = crypto.randomBytes(4).readUInt32BE(0);
     this.disallowedPropertiesInternal = new Set();
-    this.disallowedProperties = ['disallowedPropertiesInternal'];
+    this.disallowedProperties = ['disallowedPropertiesInternal', 'magicNumber'];
   }
 
   public merge(newObject: this, oldObject: this): this {

--- a/src/models/category/category-data-mapper-impl.ts
+++ b/src/models/category/category-data-mapper-impl.ts
@@ -74,7 +74,7 @@ export class CategoryDataMapperImpl extends GenericDataMapper
       .concat(';');
     return from(this.sql.query<Category>(query.text, query.values, this.factory, { cache: true }))
       .pipe(
-        map((category: Category[]) => ({ result: 'Success', data: category[0].cleanRepresentation })),
+        map((category: Category[]) => ({ result: 'Success', data: this.factory.generateApiRepresentation(category[0]) })),
       )
       .toPromise();
   }
@@ -98,7 +98,7 @@ export class CategoryDataMapperImpl extends GenericDataMapper
     query.text = query.text.concat(';');
     return from(this.sql.query<Category>(query.text, query.values, this.factory, { cache: true }))
         .pipe(
-          map((categories: Category[]) => categories.map(category => category.cleanRepresentation)),
+          map((categories: Category[]) => categories.map(category => this.factory.generateApiRepresentation(category))),
           map((categories: Array<IApiModel<Category>>) => ({
             result: 'Success',
             data: categories,
@@ -135,13 +135,13 @@ export class CategoryDataMapperImpl extends GenericDataMapper
     }
     const query = squel.insert({ autoQuoteFieldNames: true, autoQuoteTableNames: true })
       .into(this.tableName)
-      .setFieldsRows([object.dbRepresentation])
+      .setFieldsRows([this.factory.generateDbRepresentation(object)])
       .toParam();
     query.text = query.text.concat(';');
     return from(
       this.sql.query<void>(query.text, query.values, this.factory, { cache: false }),
     ).pipe(
-      map(() => ({ result: 'Success', data: object.cleanRepresentation })),
+      map(() => ({ result: 'Success', data: this.factory.generateApiRepresentation(object) })),
     ).toPromise();
   }
 
@@ -154,14 +154,14 @@ export class CategoryDataMapperImpl extends GenericDataMapper
     }
     const query = squel.update({ autoQuoteFieldNames: true, autoQuoteTableNames: true })
       .table(this.tableName)
-      .setFields(object.dbRepresentation)
+      .setFields(this.factory.generateDbRepresentation(object))
       .where(`${this.pkColumnName} = ?`, object.id)
       .toParam();
     query.text = query.text.concat(';');
     return from(
       this.sql.query<void>(query.text, query.values, this.factory, { cache: false }),
     ).pipe(
-      map(() => ({ result: 'Success', data: object.cleanRepresentation })),
+      map(() => ({ result: 'Success', data: this.factory.generateApiRepresentation(object) })),
     ).toPromise();
   }
 

--- a/src/models/category/category-factory.ts
+++ b/src/models/category/category-factory.ts
@@ -1,0 +1,31 @@
+import _ from 'lodash';
+import { IApiModel } from '../../services/database';
+import { ObjectFactory } from '../object-factory';
+import { Category } from './category';
+
+export interface ICategoryApiModel extends IApiModel<Category> {
+  uid: number;
+  categoryName: string;
+  isSponsor: boolean;
+}
+
+export class CategoryFactory extends ObjectFactory<Category> {
+  public generateApiRepresentation(data: Category): ICategoryApiModel {
+    return data.cleanRepresentation as ICategoryApiModel;
+  }
+
+  public generateDbRepresentation(data: Category): any {
+    return data.dbRepresentation;
+  }
+
+  public generateFromApi(data: ICategoryApiModel): Category {
+    return new Category()
+      .setUid(data.uid)
+      .setCategoryName(data.categoryName)
+      .setIsSponsor(data.isSponsor);
+  }
+
+  public generateFromDbRepresentation(data: any): Category {
+    return _.merge(new Category(), data);
+  }
+}

--- a/src/models/category/category.ts
+++ b/src/models/category/category.ts
@@ -1,4 +1,4 @@
-/* eslint-disable class-methods-use-this */
+// tslint:disable:import-name
 import jsonAssetLoader from '../../assets/schemas/json-asset-loader';
 import BaseObject from '../BaseObject';
 
@@ -6,20 +6,11 @@ const categorySchema = jsonAssetLoader('categorySchema');
 
 export const TABLE_NAME = 'CATEGORY_LIST';
 
-/**
- * TODO: Add documentation
- */
-interface ICategoryApiModel {
-  uid: number;
-  categoryName: string;
-  isSponsor: boolean;
-}
-
 export class Category extends BaseObject {
 
-  public uid: number;
-  public categoryName: string;
-  public isSponsor: boolean;
+  private uid: number;
+  private categoryName: string;
+  private isSponsor: boolean;
 
   public get schema() {
     return categorySchema;
@@ -27,10 +18,36 @@ export class Category extends BaseObject {
   public get id() {
     return this.uid;
   }
-  constructor(data: ICategoryApiModel) {
+
+  public constructor() {
     super();
-    this.uid = data.uid;
-    this.categoryName = data.categoryName;
-    this.isSponsor = data.isSponsor;
+  }
+
+  public setUid(uid: number) {
+    this.uid = uid;
+    return this;
+  }
+
+  public setCategoryName(name: string) {
+    this.categoryName = name;
+    return this;
+  }
+
+  public setIsSponsor(isSponsor: boolean) {
+    this.isSponsor = isSponsor;
+    return this;
+  }
+
+  public getUid() {
+    return this.uid;
+  }
+
+  public getCategoryName() {
+    return this.categoryName;
+  }
+
+  public getIsSponsor() {
+    return this.isSponsor;
   }
 }
+

--- a/src/models/object-factory.ts
+++ b/src/models/object-factory.ts
@@ -1,0 +1,19 @@
+import {
+  IApiModel,
+  IApiReadable,
+  IApiWritable,
+  IDbReadable,
+  IDbWritable,
+} from '../services/database';
+import BaseObject from './BaseObject';
+
+export abstract class ObjectFactory<T extends BaseObject>
+  implements IDbReadable<T>, IDbWritable<T>, IApiReadable<T>, IApiWritable<T> {
+  public abstract generateApiRepresentation(data: T): IApiModel<T>;
+
+  public abstract generateDbRepresentation(data: T): any;
+
+  public abstract generateFromApi(data: IApiModel<T>): T;
+
+  public abstract generateFromDbRepresentation(data: any): T;
+}

--- a/src/services/database/index.ts
+++ b/src/services/database/index.ts
@@ -1,23 +1,28 @@
 import { ICompoundHackathonUidType, Omit, UidType } from '../../JSCommon/common-types';
+import BaseObject from '../../models/BaseObject';
+import { ObjectFactory } from '../../models/object-factory';
 import { IUowOpts } from './svc/uow.service';
 
-export interface IDataMapper<T> {
+export interface IDataMapper<T extends BaseObject> {
   tableName: string;
 
-  get(object: UidType, opts?: IUowOpts): Promise<IDbResult<T>>;
+  factory: ObjectFactory<T>;
 
-  insert(object: T): Promise<IDbResult<T>>;
+  get(object: UidType, opts?: IUowOpts): Promise<IDbResult<IApiModel<T>>>;
 
-  update(object: T): Promise<IDbResult<T>>;
+  insert(object: T): Promise<IDbResult<IApiModel<T>>>;
+
+  update(object: T): Promise<IDbResult<IApiModel<T>>>;
 
   delete(object: T | UidType): Promise<IDbResult<void>>;
 
-  getAll(opts?: IUowOpts): Promise<IDbResult<T[]>>;
+  getAll(opts?: IUowOpts): Promise<IDbResult<Array<IApiModel<T>>>>;
 
   getCount(opts?: IUowOpts): Promise<IDbResult<number>>;
 }
 
-export interface IDataMapperHackathonSpecific<T> extends Omit<IDataMapper<T>, 'delete' | 'get'> {
+export interface IDataMapperHackathonSpecific<T extends BaseObject>
+  extends Omit<IDataMapper<T>, 'delete' | 'get'> {
   delete(object: ICompoundHackathonUidType): Promise<IDbResult<void>>;
 
   get(object: ICompoundHackathonUidType, opts?: IUowOpts): Promise<IDbResult<T>>;
@@ -26,4 +31,24 @@ export interface IDataMapperHackathonSpecific<T> extends Omit<IDataMapper<T>, 'd
 export interface IDbResult<T> {
   result: string;
   data: T;
+}
+
+export interface IDbReadable<T> {
+  generateFromDbRepresentation(data: any): T;
+}
+
+export interface IDbWritable<T> {
+  generateDbRepresentation(data: T): any;
+}
+
+export interface IApiReadable<T> {
+  generateFromApi(data: IApiModel<T>): T;
+}
+
+export interface IApiWritable<T> {
+  generateApiRepresentation(data: T): IApiModel<T>;
+}
+
+export interface IApiModel<T> {
+  magicNumber: number;
 }

--- a/src/services/database/svc/generic-data-mapper.ts
+++ b/src/services/database/svc/generic-data-mapper.ts
@@ -1,3 +1,4 @@
+import { ObjectFactory } from '../../../models/object-factory';
 import { AuthLevel } from '../../auth/auth-types';
 import { IAcl } from '../../auth/RBAC/rbac-types';
 import { Role } from '../../auth/RBAC/Role';

--- a/src/services/database/svc/uow.service.ts
+++ b/src/services/database/svc/uow.service.ts
@@ -1,5 +1,6 @@
 import * as squel from 'squel';
 import { UidType } from '../../../JSCommon/common-types';
+import { IDbReadable } from '../index';
 
 /**
  * A wrapper around connecting to a database backend. Performs "one unit of work" with each call.
@@ -16,10 +17,16 @@ export interface IUow {
    * allows rolling back in case of failures
    * @param {string} query Description of what action to perform
    * @param {string | string[]} params Parameters to execute query
+   * @param dbReader Reader that converts database JSON to node objects
    * @param {IQueryOpts} opts Options to modify behavior
    * @returns {Promise<any>}
    */
-  query<T>(query: string | number, params: Array<string | boolean | number>, opts: IQueryOpts): Promise<any>;
+  query<T>(
+    query: string | number,
+    params: Array<string | boolean | number>,
+    dbReader?: IDbReadable<T>,
+    opts?: IQueryOpts,
+  ): Promise<any>;
 
   /**
    * Commit a previously started transaction to the database.

--- a/tslint.json
+++ b/tslint.json
@@ -12,6 +12,7 @@
     "object-literal-sort-keys": false,
     "object-literal-shorthand": false,
     "object-shorthand-properties-first": false,
+    "import-name": false,
     "prefer-array-literal": false,
     "function-name": false,
     "no-implicit-dependencies": [true, "dev"]


### PR DESCRIPTION
This pull request is a toy example of a proposed change:
I generated four new interfaces:
```export interface IDbReadable<T> {
  generateFromDbRepresentation(data: any): T;
}

 export interface IDbWritable<T> {
  generateDbRepresentation(data: T): any;
}

 export interface IApiReadable<T> {
  generateFromApi(data: IApiModel<T>): T;
}

 export interface IApiWritable<T> {
  generateApiRepresentation(data: T): IApiModel<T>;
}
```
These will be responsible for converting data between api <-> model and model <-> db.
