### PR TITLE
address sharing permissions

### DIFF
--- a/src/models/register/registration.ts
+++ b/src/models/register/registration.ts
@@ -70,6 +70,8 @@ export interface IRegistrationApiModel {
   expectations: string | null;
   veteran: VeteranOptions;
   submitted: boolean;
+  shareAddressMlh?: boolean;
+  shareAddressSponsors?: boolean;
 }
 
 export class Registration extends BaseObject {
@@ -106,6 +108,8 @@ export class Registration extends BaseObject {
   public hackathon: string;
   public submitted: boolean;
   public pin: number;
+  public share_address_mlh: boolean;
+  public share_address_sponsors: boolean;
 
   constructor(data: IRegistrationApiModel) {
     super();
@@ -135,6 +139,9 @@ export class Registration extends BaseObject {
     this.veteran = data.veteran;
     this.time = data.time;
     this.submitted = data.submitted;
+    this.share_address_mlh = data.shareAddressMlh || false;
+    this.share_address_sponsors = data.shareAddressSponsors || false;
+;
     // this.hackathon = data.hackathon;
   }
 

--- a/src/router/routes/users.ts
+++ b/src/router/routes/users.ts
@@ -222,6 +222,8 @@ export class UsersController extends ParentRouter implements IExpressController 
    * @apiParam {String} project A project description that the user is proud of
    * @apiParam {String} expectations What the user expects to get from the hackathon
    * @apiParam {String} veteran=false Is the user a veteran?
+   * @apiParam {Boolean} shareAddressMlh Does the user agree to share their address with mlh?
+   * @apiParam {Boolean} shareAddressSponsors Does the user agree to share their address with event sponsors
    *
    * @apiSuccess {Registration} data The inserted registration
    * @apiUse IllegalArgumentError

--- a/test/e2e/admin/admin-statistics.test.ts
+++ b/test/e2e/admin/admin-statistics.test.ts
@@ -325,6 +325,8 @@ class AdminStatisticsIntegrationTest extends IntegrationTest {
     delete result[uid].attendees[0].eighteenBeforeEvent;
     delete result[uid].attendees[0].mlh_coc;
     delete result[uid].attendees[0].mlh_dcp;
+    delete result[uid].attendees[0].share_address_mlh;
+    delete result[uid].attendees[0].share_address_sponsors;
     delete result[uid].attendees[0].submitted;
     delete result[uid].attendees[0].time;
     this.expect(data).to.deep.equal(result);
@@ -353,6 +355,8 @@ class AdminStatisticsIntegrationTest extends IntegrationTest {
     delete result[uid].uid;
     delete result[uid].mlh_coc;
     delete result[uid].mlh_dcp;
+    delete result[uid].share_address_mlh;
+    delete result[uid].share_address_sponsors;
     delete result[uid].submitted;
     delete result[uid].eighteenBeforeEvent;
     delete result[uid].time;

--- a/test/e2e/test-data.ts
+++ b/test/e2e/test-data.ts
@@ -66,6 +66,8 @@ export class TestData {
       veteran: VeteranOptions.NO,
       time: 0,
       submitted: false,
+      shareAddressMlh: false,
+      shareAddressSponsors: false,
     };
   }
 

--- a/test/models/register/register-data-mapper-impl.test.ts
+++ b/test/models/register/register-data-mapper-impl.test.ts
@@ -54,6 +54,8 @@ const validRegistration = new Registration({
   veteran: VeteranOptions.NODISCLOSE,
   time: Date.now(),
   submitted: true,
+  shareAddressMlh: false,
+  shareAddressSponsors: false,
 });
 
 describe('TEST: Register data mapper', () => {
@@ -351,8 +353,8 @@ describe('TEST: Register data mapper', () => {
         '`shirt_size`, `travel_reimbursement`, `first_hackathon`, `university`, `email`, ' +
         '`academic_year`, `major`, `phone`, `race`, `coding_experience`, `uid`, ' +
         '`eighteenBeforeEvent`, `mlh_coc`, `mlh_dcp`, `referral`, `project`, `expectations`, ' +
-        '`veteran`, `time`, `submitted`, `hackathon`) ' +
-        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
+        '`veteran`, `time`, `submitted`, `share_address_mlh`, `share_address_sponsors`, `hackathon`) ' +
+        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);';
       const expectedParams = [
         validRegistration.firstname,
         validRegistration.lastname,
@@ -377,6 +379,8 @@ describe('TEST: Register data mapper', () => {
         validRegistration.veteran,
         validRegistration.time,
         true,
+        validRegistration.share_address_mlh,
+        validRegistration.share_address_sponsors,
         'test uid',
       ];
       const [generatedSQL, generatedParams] = capture<string, string[]>(mysqlUowMock.query)
@@ -416,6 +420,8 @@ describe('TEST: Register data mapper', () => {
         veteran: VeteranOptions.NODISCLOSE,
         time: Date.now(),
         submitted: true,
+        shareAddressMlh: false,
+        shareAddressSponsors: false,
       });
       // WHEN: Adding an invalid registration
       try {
@@ -493,7 +499,7 @@ describe('TEST: Register data mapper', () => {
         '`shirt_size` = ?, `travel_reimbursement` = ?, `first_hackathon` = ?, `university` = ?, ' +
         '`email` = ?, `academic_year` = ?, `major` = ?, `phone` = ?, `race` = ?, `coding_experience` = ?, ' +
         '`uid` = ?, `eighteenBeforeEvent` = ?, `mlh_coc` = ?, `mlh_dcp` = ?, `referral` = ?, `project` = ?, ' +
-        '`expectations` = ?, `veteran` = ?, `time` = ?, `submitted` = ?, `hackathon` = ? ' +
+        '`expectations` = ?, `veteran` = ?, `time` = ?, `submitted` = ?, `share_address_mlh` = ?, `share_address_sponsors` = ?, `hackathon` = ? ' +
         'WHERE (uid = ?) AND (hackathon = ?);';
       const expectedParams = [
         validRegistration.firstname,
@@ -519,6 +525,8 @@ describe('TEST: Register data mapper', () => {
         validRegistration.veteran,
         validRegistration.time,
         true,
+        validRegistration.share_address_mlh,
+        validRegistration.share_address_sponsors,
         validRegistration.hackathon,
         validRegistration.id,
         validRegistration.hackathon,
@@ -560,6 +568,8 @@ describe('TEST: Register data mapper', () => {
         veteran: VeteranOptions.NODISCLOSE,
         time: Date.now(),
         submitted: false,
+        shareAddressMlh: false,
+        shareAddressSponsors: false,
       });
       // WHEN: Updating an invalid registration
       try {

--- a/test/processors/registration-processor.test.ts
+++ b/test/processors/registration-processor.test.ts
@@ -49,6 +49,8 @@ const registration = new Registration({
   veteran: VeteranOptions.NODISCLOSE,
   time: Date.now(),
   submitted: true,
+  shareAddressMlh: false,
+  shareAddressSponsors: false
 });
 
 describe('TEST: Registration Processor', () => {


### PR DESCRIPTION
Added two boolean variables to Registrations for permissions for sharing address with MLH and sponsors,

Integration tests in admin-statistics _might_ need to be un-cheesed.
(currently deleting them from the expected output because staging hasn't been updated)