### PR TITLE
Fix event to allow string locations

### DIFF
--- a/src/models/event/event.ts
+++ b/src/models/event/event.ts
@@ -13,7 +13,7 @@ export enum EventType {
 
 export interface IEventApiModel {
   uid?: UidType;
-  eventLocation: number;
+  eventLocation: number | string;
   eventStartTime: number;
   eventEndTime: number;
   eventTitle: string;
@@ -43,7 +43,7 @@ export class Event extends BaseObject {
   constructor(data: IEventApiModel) {
     super();
     this.uid = data.uid || uuid.v4().replace(/-/g, '');
-    this.event_location = data.eventLocation;
+    this.event_location = Number(data.eventLocation);
     this.event_start_time = data.eventStartTime;
     this.event_end_time = data.eventEndTime;
     this.event_title = data.eventTitle;

--- a/src/router/routes/live/events.ts
+++ b/src/router/routes/live/events.ts
@@ -170,6 +170,9 @@ export class EventsController extends LiveController {
     if (!request.body.eventType) {
       return Util.standardErrorHandler(new HttpError('Event type must be provided', 400), next);
     }
+    if (isNaN(Number(request.body.eventLocation))) {
+      return Util.standardErrorHandler(new HttpError('Event location must be a parsable number', 400), next);
+    }
     let event;
     try {
       event = new Event(request.body);


### PR DESCRIPTION
A long time ago I changed event to match the database types but I didn't realize the frontend sent strings for everything. This should fix that by converting them to numbers.