### PR TITLE
Jdurrell/ec single class deletion

### DIFF
--- a/src/models/event/event.ts
+++ b/src/models/event/event.ts
@@ -50,7 +50,7 @@ export class Event extends BaseObject {
   public hackathon?: UidType;
   public ws_presenter_names?: string;
   public ws_skill_level?: string;
-  public ws_relevant_skills;
+  public ws_relevant_skills?: string;
   public ws_urls?: string[];
   public event_icon?: string;
 

--- a/src/models/extra-credit/extra-credit-assignment.ts
+++ b/src/models/extra-credit/extra-credit-assignment.ts
@@ -4,8 +4,9 @@ import BaseObject from '../BaseObject';
 
 const extraCreditAssignmentSchema = jsonAssetLoader('extraCreditAssignmentSchema');
 export interface IExtraCreditAssignmentApiModel {
-  uid: UidType;
-  cid: number;
+  userUid: UidType;
+  classUid: number;
+  uid?: number;
 }
 
 export class ExtraCreditAssignment extends BaseObject {
@@ -19,12 +20,13 @@ export class ExtraCreditAssignment extends BaseObject {
 
   public readonly class_uid: number;
   public readonly user_uid: UidType;
-  public uid: number;
+  public uid?: number;
   public hackathon: UidType;
 
   constructor(data: IExtraCreditAssignmentApiModel) {
     super();
-    this.class_uid = data.cid;
-    this.user_uid = data.uid;
+    this.class_uid = data.classUid;
+    this.user_uid = data.userUid;
+    this.uid = data.uid;
   }
 }

--- a/src/router/routes/users.ts
+++ b/src/router/routes/users.ts
@@ -495,7 +495,7 @@ export class UsersController extends ParentRouter implements IExpressController 
   * @apiGroup User
   * @apiPermission DirectorPermission
   *
-  * @apiParam {String} uid The id associated with the hacker
+  * @apiParam {String} uid The id associated with the assignment
   * @apiParam {String} hackathonUid The id associated with the current hackathon
   * @apiUse AuthArgumentRequired
   * @apiUse IllegalArgumentError
@@ -513,7 +513,8 @@ export class UsersController extends ParentRouter implements IExpressController 
       return Util.standardErrorHandler(new HttpError('Could not find valid assignment uid', 400), next);
     }
     try {
-      const ecAssignment = new ExtraCreditAssignment({ uid: req.body.uid, cid: 1 });
+      const ecAssignment = new ExtraCreditAssignment({ uid: "hackpsu", cid: 1 });
+      ecAssignment.uid = req.body.uid;
       const result = await this.extraCreditDataMapper.delete(ecAssignment);
       const response = new ResponseBody(
         'Success',

--- a/src/router/routes/users.ts
+++ b/src/router/routes/users.ts
@@ -513,8 +513,11 @@ export class UsersController extends ParentRouter implements IExpressController 
       return Util.standardErrorHandler(new HttpError('Could not find valid assignment uid', 400), next);
     }
     try {
-      const ecAssignment = new ExtraCreditAssignment({ uid: "hackpsu", cid: 1 });
-      ecAssignment.uid = req.body.uid;
+      const ecAssignment = new ExtraCreditAssignment({
+        uid: req.body.uid,
+        userUid: 'temp',
+        classUid: 1,
+      });
       const result = await this.extraCreditDataMapper.delete(ecAssignment);
       const response = new ResponseBody(
         'Success',

--- a/test/e2e/test-data.ts
+++ b/test/e2e/test-data.ts
@@ -139,8 +139,8 @@ export class TestData {
 
   public static validExtraCreditAssignment(): IExtraCreditAssignmentApiModel {
     return {
-      uid: this.validRegistration().uid as string,
-      cid: 5,
+      userUid: this.validRegistration().uid as string,
+      classUid: 5,
     };
   }
 

--- a/test/models/extra-credit/extra-credit-data-mapper-impl.test.ts
+++ b/test/models/extra-credit/extra-credit-data-mapper-impl.test.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import 'mocha';
 import { of } from 'rxjs';
 import { anyString, anything, capture, instance, mock, reset, verify, when } from 'ts-mockito';
+import { IExtraCreditDataMapper } from '../../../src/models/extra-credit';
 import { ExtraCreditAssignment } from '../../../src/models/extra-credit/extra-credit-assignment';
 import { ExtraCreditDataMapperImpl } from '../../../src/models/extra-credit/extra-credit-data-mapper-impl';
 import { IActiveHackathonDataMapper } from '../../../src/models/hackathon/active-hackathon';
@@ -13,7 +14,7 @@ import { IDataMapper } from '../../../src/services/database';
 import { MysqlUow } from '../../../src/services/database/svc/mysql-uow.service';
 import { Logger } from '../../../src/services/logging/logging';
 
-let extraCreditDataMapper: IDataMapper<ExtraCreditAssignment>;
+let extraCreditDataMapper: IExtraCreditDataMapper;
 let activeHackathonDataMapper;
 let mysqlUow: MysqlUow;
 const mysqlUowMock = mock(MysqlUow);
@@ -75,13 +76,14 @@ describe('TEST: Extra Credit Data Mapper', () => {
         uid: 'test',
         cid: 0,
       });
+      testExtraCreditAssignment.uid = 1234;
 
       // WHEN: Retrieving data for this extra credit assignment
       await extraCreditDataMapper.delete(testExtraCreditAssignment);
 
       // THEN: Generated SQL matches the expectation
       const expectedSQL = 'DELETE FROM `EXTRA_CREDIT_ASSIGNMENT` WHERE (uid = ?);';
-      const expectedParams = [undefined];
+      const expectedParams = [1234];
       const [generatedSQL, generatedParams] = capture<string, any[]>(mysqlUowMock.query)
         .first();
       verify(mysqlUowMock.query(anything(), anything(), anything())).once();

--- a/test/models/extra-credit/extra-credit-data-mapper-impl.test.ts
+++ b/test/models/extra-credit/extra-credit-data-mapper-impl.test.ts
@@ -73,10 +73,10 @@ describe('TEST: Extra Credit Data Mapper', () => {
     it('causes the extra credit assignment to get deleted', async () => {
       // GIVEN: An extra credit assignment with a valid ID to read from
       const testExtraCreditAssignment = new ExtraCreditAssignment({
-        uid: 'test',
-        cid: 0,
+        userUid: 'test',
+        classUid: 0,
+        uid: 1234,
       });
-      testExtraCreditAssignment.uid = 1234;
 
       // WHEN: Retrieving data for this extra credit assignment
       await extraCreditDataMapper.delete(testExtraCreditAssignment);
@@ -164,8 +164,8 @@ describe('TEST: Extra Credit Data Mapper', () => {
     it('inserts an extra credit assignment', async () => {
       // GIVEN: An extra credit assignment to insert
       const testExtraCreditAssignment = new ExtraCreditAssignment({
-        uid: 'test',
-        cid: 0,
+        userUid: 'test',
+        classUid: 0,
       });
       testExtraCreditAssignment.hackathon = 'test uid';
       // WHEN: Retrieving number of extra credit assignments


### PR DESCRIPTION
A few questions for this one:

1. Is [https://api.hackpsu.org/v2/doc/#api-User-Remove_Extra_Credit_Assignment](https://api.hackpsu.org/v2/doc/#api-User-Remove_Extra_Credit_Assignment) already supposed to cover this functionality? It looks like it was intended to, but it doesn't look like it actually does. If it _was_ supposed to, then I can copy this functionality into where it's supposed to be instead of creating a new api endpoint for it.

2. Is there anything else I need to do to actually publish a new endpoint?

3. Does this need integration tests attached to it? I added a unit test for generating the correct SQL, but the other extra credit functions didn't have integration tests, so I skipped that for this one.